### PR TITLE
Add python3 support

### DIFF
--- a/splunk-aws-automation/lambda_code/splunk_cwe_firehose_processor_v0.2/lambda_function.py
+++ b/splunk-aws-automation/lambda_code/splunk_cwe_firehose_processor_v0.2/lambda_function.py
@@ -26,29 +26,24 @@ Cloudwatch Logs sends to Firehose records that look like this:
   ]
 }
 
-The data is additionally compressed with GZIP.
-
 The code below will:
 
-1) Gunzip the data
-2) Parse the json
-3) Set the result to ProcessingFailed for any record whose messageType is not DATA_MESSAGE, thus redirecting them to the
+1) Parse the json
+2) Set the result to ProcessingFailed for any record whose messageType is not DATA_MESSAGE, thus redirecting them to the
    processing error output. Such records do not contain any log events. You can modify the code to set the result to
    Dropped instead to get rid of these records completely.
-4) For records whose messageType is DATA_MESSAGE, extract the individual log events from the logEvents field, and pass
+3) For records whose messageType is DATA_MESSAGE, extract the individual log events from the logEvents field, and pass
    each one to the transformLogEvent method. You can modify the transformLogEvent method to perform custom
    transformations on the log events.
-5) Concatenate the result from (4) together and set the result as the data of the record returned to Firehose. Note that
+4) Concatenate the result from (3) together and set the result as the data of the record returned to Firehose. Note that
    this step will not add any delimiters. Delimiters should be appended by the logic within the transformLogEvent
    method.
-6) Any additional records which exceed 6MB will be re-ingested back into Firehose.
+5) Any additional records which exceed 6MB will be re-ingested back into Firehose.
 
 """
 
 import base64
 import json
-import gzip
-import StringIO
 import boto3
 
 

--- a/splunk-aws-automation/lambda_code/splunk_cwe_firehose_processor_v0.2/lambda_function.py
+++ b/splunk-aws-automation/lambda_code/splunk_cwe_firehose_processor_v0.2/lambda_function.py
@@ -43,9 +43,11 @@ The code below will:
 """
 
 import base64
-import json
 import boto3
+import json
+import sys
 
+IS_PY3 = sys.version_info[0] == 3
 
 def transformLogEvent(log_event, source):
     """Transform each log event.
@@ -81,7 +83,11 @@ def processRecords(records):
         return_event['sourcetype'] = st
         return_event['event'] = data['detail']
 
-        data = base64.b64encode(json.dumps(return_event))
+        if IS_PY3:
+            # base64 encode api changes in python3 to operate exclusively on byte-like objects and bytes
+            data = base64.b64encode(json.dumps(return_event).encode('utf-8')).decode()
+        else:
+            data = base64.b64encode(json.dumps(return_event))
         yield {
             'data': data,
             'result': 'Ok',

--- a/splunk-aws-automation/lambda_code/splunk_cwl_firehose_processor_v0.2/lambda_function.py
+++ b/splunk-aws-automation/lambda_code/splunk_cwl_firehose_processor_v0.2/lambda_function.py
@@ -80,7 +80,7 @@ def processRecords(records):
     for r in records:
         data = base64.b64decode(r['data'])
         if IS_PY3:
-            striodata = io.StringIO(data)
+            striodata = io.StringIO(data.decode())
         else:
             striodata = StringIO.StringIO(data)
 

--- a/splunk-aws-automation/lambda_code/splunk_cwl_firehose_processor_v0.2/lambda_function.py
+++ b/splunk-aws-automation/lambda_code/splunk_cwl_firehose_processor_v0.2/lambda_function.py
@@ -80,11 +80,11 @@ def processRecords(records):
     for r in records:
         data = base64.b64decode(r['data'])
         if IS_PY3:
-            striodata = io.StringIO(data.decode())
+            iodata = io.BytesIO(data)
         else:
-            striodata = StringIO.StringIO(data)
+            iodata = StringIO.StringIO(data)
 
-        with gzip.GzipFile(fileobj=striodata, mode='r') as f:
+        with gzip.GzipFile(fileobj=iodata, mode='r') as f:
             data = json.loads(f.read())
 
         recId = r['recordId']

--- a/splunk-aws-automation/lambda_code/splunk_cwl_firehose_processor_v0.2/lambda_function.py
+++ b/splunk-aws-automation/lambda_code/splunk_cwl_firehose_processor_v0.2/lambda_function.py
@@ -48,9 +48,15 @@ The code below will:
 import base64
 import json
 import gzip
-import StringIO
 import boto3
+import sys
 
+IS_PY3 = sys.version_info[0] == 3
+
+if IS_PY3:
+    import io
+else:
+    import StringIO
 
 def transformLogEvent(log_event, source):
     """Transform each log event.
@@ -73,7 +79,11 @@ def transformLogEvent(log_event, source):
 def processRecords(records):
     for r in records:
         data = base64.b64decode(r['data'])
-        striodata = StringIO.StringIO(data)
+        if IS_PY3:
+            striodata = io.StringIO(data)
+        else:
+            striodata = StringIO.StringIO(data)
+
         with gzip.GzipFile(fileobj=striodata, mode='r') as f:
             data = json.loads(f.read())
 
@@ -90,7 +100,10 @@ def processRecords(records):
         elif data['messageType'] == 'DATA_MESSAGE':
             source = data['logGroup'] + ":" + data['logStream']
             data = ''.join([transformLogEvent(e, source) for e in data['logEvents']])
-            data = base64.b64encode(data)
+            if IS_PY3:
+                data = base64.b64encode(data.encode('utf-8')).decode()
+            else:
+                data = base64.b64encode(data)
             yield {
                 'data': data,
                 'result': 'Ok',

--- a/splunk-aws-automation/lambda_code/splunk_vpc_firehose_processor_v0.2/lambda_function.py
+++ b/splunk-aws-automation/lambda_code/splunk_vpc_firehose_processor_v0.2/lambda_function.py
@@ -81,10 +81,10 @@ def processRecords(records):
     for r in records:
         data = base64.b64decode(r['data'])
         if IS_PY3:
-            striodata = io.StringIO(data.decode())
+            iodata = io.BytesIO(data)
         else:
-            striodata = StringIO.StringIO(data)
-        with gzip.GzipFile(fileobj=striodata, mode='r') as f:
+            iodata = StringIO.StringIO(data)
+        with gzip.GzipFile(fileobj=iodata, mode='r') as f:
             data = json.loads(f.read())
 
         recId = r['recordId']

--- a/splunk-aws-automation/lambda_code/splunk_vpc_firehose_processor_v0.2/lambda_function.py
+++ b/splunk-aws-automation/lambda_code/splunk_vpc_firehose_processor_v0.2/lambda_function.py
@@ -81,7 +81,7 @@ def processRecords(records):
     for r in records:
         data = base64.b64decode(r['data'])
         if IS_PY3:
-            striodata = io.StringIO(data)
+            striodata = io.StringIO(data.decode())
         else:
             striodata = StringIO.StringIO(data)
         with gzip.GzipFile(fileobj=striodata, mode='r') as f:


### PR DESCRIPTION
Python 3 made changes to the `base64` API to operate on byte-like objects and bytes.  
This update detects when the code is running in Python 3 and will use the newer logic for encode/decode.