### PR TITLE
Fix payload limit (bug) in Splunk CWE lambda

### DIFF
--- a/splunk-aws-automation/lambda_code/splunk_cwe_firehose_processor_v0.4/lambda_function.py
+++ b/splunk-aws-automation/lambda_code/splunk_cwe_firehose_processor_v0.4/lambda_function.py
@@ -104,7 +104,7 @@ def processRecords(records):
         else:
             data = base64.b64encode(json.dumps(return_event))
 
-        if len(data) <= 600000:
+        if len(data) <= 6000000:
             yield {
                 'data': data,
                 'result': 'Ok',


### PR DESCRIPTION
Payload limitation test appears to contain a type-o of 600K instead of 6M in the CWE Lambda Function.